### PR TITLE
Add DateTime editor widget

### DIFF
--- a/libraries.json
+++ b/libraries.json
@@ -387,6 +387,18 @@
       "attempted"
     ]
   },
+  "H5PEditor.DateTime": {
+    "id": "H5PEditor.GameMap",
+    "title": "H5PEditor.DateTime",
+    "repo": {
+      "type": "github",
+      "url": "https://github.com/otacke/h5p-editor-datetime"
+    },
+    "resume": false,
+    "fullscreen": false,
+    "author": "Oliver Tacke",
+    "runnable": false
+  },
   "H5PEditor.GameMap": {
     "id": "H5PEditor.GameMap",
     "title": "Game map editor",


### PR DESCRIPTION
When merged in, will add the DateTime editor widget that's required by GameMap since version 1.4 (H5P Group is serving 1.5).